### PR TITLE
otu caller: put intersect before merging

### DIFF
--- a/otu_caller.py
+++ b/otu_caller.py
@@ -651,6 +651,11 @@ if __name__ == '__main__':
     if oc.primers == True:
         message('Removing primers')
         oc.remove_primers()
+
+    # Intersect reads
+    if oc.intersect:
+        message("Intersecting reads")
+        oc.intersect_reads()
     
     # Merge reads
     if oc.merge:
@@ -662,11 +667,6 @@ if __name__ == '__main__':
         oc.ci = oc.mi
     else:
         oc.ci = oc.fi
-
-    # Intersect reads
-    if oc.intersect:
-        message("Intersecting reads")
-        oc.intersect_reads()
     
     # Demultiplex
     if oc.demultiplex == True:


### PR DESCRIPTION
Intersection was happening after merging. It should come before, otherwise merging will fail.
